### PR TITLE
Add note about appending `/callback` to program endpoint URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [Membrane.io](https://membrane.io/) driver for Twitter.
 
 ## Setup
 
-Get Oauth2 [Client key and secret](https://developer.twitter.com/en/portal) from twitter dev portal and setup your [Callback URI](https://developer.twitter.com/en/docs/apps/callback-urls) with the program Endpoint URL.
+Get Oauth2 [Client key and secret](https://developer.twitter.com/en/portal) from twitter dev portal and setup your [Callback URI](https://developer.twitter.com/en/docs/apps/callback-urls) by appending `/callback` to the program Endpoint URL.
 
 $~~~~$`mctl action "twitter:configure(CLIENT_ID:'<string>',CLIENT_SECRET:'<string>')"`
 


### PR DESCRIPTION
While configuring the Twitter driver, I noticed [here](https://github.com/membrane-io/membrane-driver-twitter/blob/main/index.ts) to append `/callback` to the driver program endpoint URL.